### PR TITLE
Update ASM visitors to support newer class versions

### DIFF
--- a/src/main/java/gate/creole/Plugin.java
+++ b/src/main/java/gate/creole/Plugin.java
@@ -1082,7 +1082,7 @@ public abstract class Plugin {
       // we've found a CreoleResource annotation on this class
       if(desc.equals(CREOLE_RESOURCE_DESC)) {
         foundCreoleResource = true;
-        return new AnnotationVisitor(Opcodes.ASM5) {
+        return new AnnotationVisitor(Opcodes.ASM9) {
           @Override
           public void visit(String name, Object value) {
             if(name.equals("name") && resInfo.getResourceName() == null) {

--- a/src/main/java/gate/util/asm/commons/EmptyVisitor.java
+++ b/src/main/java/gate/util/asm/commons/EmptyVisitor.java
@@ -10,7 +10,7 @@ import gate.util.asm.TypePath;
 
 public class EmptyVisitor extends ClassVisitor {
 
-  AnnotationVisitor av = new AnnotationVisitor(Opcodes.ASM5) {
+  AnnotationVisitor av = new AnnotationVisitor(Opcodes.ASM9) {
 
       @Override
       public AnnotationVisitor visitAnnotation(String name, String desc) {
@@ -24,7 +24,7 @@ public class EmptyVisitor extends ClassVisitor {
   };
 
   public EmptyVisitor() {
-      super(Opcodes.ASM5);
+      super(Opcodes.ASM9);
   }
 
   @Override
@@ -41,7 +41,7 @@ public class EmptyVisitor extends ClassVisitor {
   @Override
   public FieldVisitor visitField(int access, String name, String desc,
           String signature, Object value) {
-      return new FieldVisitor(Opcodes.ASM5) {
+      return new FieldVisitor(Opcodes.ASM9) {
 
           @Override
           public AnnotationVisitor visitAnnotation(String desc,
@@ -60,7 +60,7 @@ public class EmptyVisitor extends ClassVisitor {
   @Override
   public MethodVisitor visitMethod(int access, String name, String desc,
           String signature, String[] exceptions) {
-      return new MethodVisitor(Opcodes.ASM5) {
+      return new MethodVisitor(Opcodes.ASM9) {
 
           @Override
           public AnnotationVisitor visitAnnotationDefault() {


### PR DESCRIPTION
While we've updated `gate-asm` to ASM version 9, we are still using `Opcodes.ASM5`, which causes users of our visitors (notably `DumpCreoleToXML` in the maven builds of plugins) to throw exceptions when asked to process class files compiled for Java 11 or later using newer class file format features like `NestHost`/`NestMembers`.  This PR switches to `Opcodes.ASM9`, which fixes these issues.

This PR has been tested by creating a dummy plugin that compiles with Java 11 and includes an inner class that calls a private method of its enclosing class (which is what triggers the `NestMembers` attribute).  When building against a `master` version of `gate-core` this produces an error

```
[ERROR] Failed to execute goal uk.ac.gate:gate-maven-plugin:9.1-SNAPSHOT:DumpCreoleToXML (default) on project dummy-plugin: error expanding creole: NestMember requires ASM7 -> [Help 1]
```

but when building against a `gate-core` built from this PR branch `DumpCreoleToXML` runs successfully and generates the correct `-creole.jar`.

Closes #160