### PR TITLE
Upgrade GitHub actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Upload artifact
         if: env.GITHUB_PAGES == 'true'
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: 'target/site'
@@ -139,7 +139,7 @@ jobs:
 
       - name: Deploy site to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4
         if: env.GITHUB_PAGES == 'true'
 
   downstream:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout Master Branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v5
         continue-on-error: true
         # This step may error out when run in a fork that doesn't have pages
         # enabled - if this happens, run the rest but skip anything that
@@ -36,7 +36,7 @@ jobs:
         # to subsequent steps, so we can condition on that.
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '8'
           distribution: 'zulu'
@@ -149,7 +149,7 @@ jobs:
 
     steps:
       - name: "Trigger gate-top"
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GATE_TOP_TOKEN }}
           script: |

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '8'
           distribution: 'zulu'

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Upload Test Results
         if: success() || failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Test Results
           path: |
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Event File
           path: ${{ github.event_path }}


### PR DESCRIPTION
- upgrade `upload-artifact` action to v4, since v3 will stop working soon
  - also upgrade `upload-pages-artifact`, which has a transitive dependency on `upload-artifact`
- upgrade `checkout` and `github-script` actions to their latest releases.